### PR TITLE
tempFix(validator) Fix temporaire pour pouvoir faire une installation initial

### DIFF
--- a/passion-lecture/app/validators/book.ts
+++ b/passion-lecture/app/validators/book.ts
@@ -2,17 +2,24 @@ import Author from '#models/author'
 import Category from '#models/category'
 import vine from '@vinejs/vine'
 
-const author = await Author.all()
-const authorIds = await author.map((s) => s.id)
+// const author = await Author.all()
+// const authorIds = await author.map((s) => s.id)
 
-const category = await Category.all()
-const categoryIds = category.map((c) => c.id)
+// const category = await Category.all()
+// const categoryIds = category.map((c) => c.id)
+
+// ------------------------------------------
+// TODO trouver un autre moyen de valider les si les id sont existants.
+// Sur une installation propre celà lance des requetes sql dans le vide au lancement du serveur node
+// Du coup impossible de faire les migrations initiales et d'init le serveur (npm run dev)
+// Bisous, Brendan.
+// ------------------------------------------
 
 const bookValidator = vine.compile(
   vine.object({
     title: vine.string().minLength(2).maxLength(255),
-    categoryId: vine.number().in(categoryIds),
-    authorId: vine.number().in(authorIds),
+    categoryId: vine.number() /*.in(categoryIds)*/,
+    authorId: vine.number() /*.in(authorIds)*/,
     numberOfPages: vine.number(),
     pdfLink: vine.string().minLength(2).maxLength(255),
     editor: vine.string().minLength(2).maxLength(255),


### PR DESCRIPTION
// ------------------------------------------
// TODO trouver un autre moyen de valider les si les id sont existants. // Sur une installation propre cela lance des requêtes sql dans le vide au lancement du serveur node // Du coup impossible de faire les migrations initiales et d'init le serveur (npm run dev) // Bisous, Brendan.
// ------------------------------------------